### PR TITLE
PoC for Deploying "Testkube" Load Testing Tool

### DIFF
--- a/k8s-examples/testkube/README.md
+++ b/k8s-examples/testkube/README.md
@@ -1,0 +1,40 @@
+
+# Deploying the `testkube` Framework to AWS EKS
+
+## How to Deploy and Verify, Step by Step
+
+*Prerequisites:* Have the EKS cluster, Nginx Ingress Controller, and DNS configuration, and ACK Service Controllers for
+RDS/S3 set up per the instructions in the [root README.md](../../README.md).
+
+Change directory to `./k8s-examples/testkube/`, modify the `testkube-values.yaml` manifest by replacing all occurrences
+of app domain `"testkube.k8s.mabl.se"` with your own domain name, then install Testkube using its Helm chart:
+
+    cd k8s-examples/testkube/
+    vi testkube-values.yaml
+    helm repo add kubeshop https://kubeshop.github.io/helm-charts && helm repo update
+    helm install --create-namespace testkube kubeshop/testkube --namespace=testkube --values testkube-values.yaml
+
+Create a GitHub OAuth application per the
+[OAuth for Testkube Dashboard](https://kubeshop.github.io/testkube/guides/getting-to-production/authentication/oauth-ui)
+instruction and upgrade the Helm installation with the new values:
+
+    export GH_OAUTH2_CLIENT_ID=61****************22
+    export GH_OAUTH2_CLIENT_SECRET=7a1**********************************501
+    export GH_OAUTH2_GITHUB_ORG=MyUserOrg
+    export GH_OAUTH2_COOKIE_SECRET=$(openssl rand -hex 16)
+    helm upgrade testkube kubeshop/testkube --namespace=testkube --values testkube-values.yaml \
+      --set testkube-dashboard.oauth2.enabled=true \
+      --set testkube-dashboard.oauth2.env.clientId=$GH_OAUTH2_CLIENT_ID \
+      --set testkube-dashboard.oauth2.env.clientSecret=$GH_OAUTH2_CLIENT_SECRET \
+      --set testkube-dashboard.oauth2.env.githubOrg=$GH_OAUTH2_GITHUB_ORG \
+      --set testkube-dashboard.oauth2.env.cookieSecret=$GH_OAUTH2_COOKIE_SECRET \
+      --set testkube-dashboard.oauth2.env.cookieSecure="true"
+
+Open the address in your browser and expect to be faced with a GitHub authentication screen and, upon authenticating,
+find yourself redirected to the Testkube dashboard (example URL [works for me](https://testkube.k8s.mabl.se/)):
+
+    open https://testkube.k8s.mabl.se/
+
+Now go celebrate! :boom:
+
+

--- a/k8s-examples/testkube/testkube-values.yaml
+++ b/k8s-examples/testkube/testkube-values.yaml
@@ -211,7 +211,7 @@ testkube-api:
           - testkube.k8s.mabl.se
         secretName: testkube-cert-secret
   cliIngress:
-    enabled: true
+    enabled: false
     annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/rewrite-target: /$1

--- a/k8s-examples/testkube/testkube-values.yaml
+++ b/k8s-examples/testkube/testkube-values.yaml
@@ -1,0 +1,353 @@
+# Demo values for testkube.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ""
+  pullPolicy: Never
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: "testkube"
+fullnameOverride: "testkube"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+# fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: "false"
+  className: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# For more configuration parameters of MongoDB chart please look here:
+# https://github.com/bitnami/charts/tree/master/bitnami/mongodb#parameters
+mongodb:
+  enabled: true
+  nameOverride: "mongodb"
+  fullnameOverride: "testkube-mongodb"
+  architecture: "standalone"
+  auth:
+    enabled: false
+    # rootPassword: "123DefaultOne321"
+  service:
+    port: "27017"
+    portName: "mongodb"
+    nodePort: true
+    clusterIP: ""
+
+testkube-api:
+  rbac:
+    createRoles: true
+    createRoleBindings: true
+  prometheus:
+    enabled: false
+  nameOverride: "api-server"
+  fullnameOverride: "testkube-api-server"
+  image:
+    repository: kubeshop/testkube-api-server
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    # TODO we should stick to static version
+    # tag: "latest"
+  service:
+    type: ClusterIP
+    port: 8088
+  minio:
+    enabled: true
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    image:
+      registry: docker.io
+      repository: minio/minio
+      tag: latest
+  uiIngress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
+      nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
+      # specify the name of the global IP address resource to be associated with the HTTP(S) Load Balancer.
+      kubernetes.io/ingress.global-static-ip-name: testkube-demo
+      # add an annotation indicating the issuer to use.
+      # cert-manager.io/cluster-issuer: letsencrypt-prod
+      # controls whether the ingress is modified ‘in-place’,
+      # or a new one is created specifically for the HTTP01 challenge.
+      # acme.cert-manager.io/http01-edit-in-place: "true"
+
+      # for websockets
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+
+      nginx.ingress.kubernetes.io/server-snippet: |
+        set $methodallowed "";
+        set $pathallowed "";
+
+        if ( $request_method = GET ){
+          set $methodallowed "true";
+          set $pathallowed "true";
+        }
+
+        if ( $request_method = POST ){
+          set $methodallowed "true";
+        }
+
+        if ( $request_method = PATCH ){
+          set $methodallowed "true";
+        }
+
+        if ( $uri ~ "^(.*)/tests/(.*)/executions$" ){
+          set $pathallowed "true";
+        }
+
+        if ( $uri ~ "^(.*)/tests/(.*)/executions/(.*)$" ){
+          set $pathallowed "true";
+        }
+
+        if ( $uri ~ "^(.*)/test-suites/(.*)/executions$" ){
+          set $pathallowed "true";
+        }
+
+        if ( $uri ~ "^(.*)/test-suites/(.*)/executions/(.*)$" ){
+          set $pathallowed "true";
+        }
+
+        if ( $uri ~ "^(.*)/tests$" ){
+          set $pathallowed "true";
+        }
+
+        if ( $uri ~ "^(.*)/tests/(.*)$" ){
+          set $pathallowed "true";
+        }
+
+        if ( $uri ~ "^(.*)/test-suite-executions/(.*)$" ){
+          set $pathallowed "true";
+        }
+
+        set $condition "$methodallowed+$pathallowed";
+        if ( $condition != "true+true" ) {
+          return 401;
+        }
+
+    path: /results/(v\d/.*)
+    hosts:
+      - demo.testkube.io
+    tlsenabled: "true"
+    tls: # < placing a host in the TLS config will indicate a certificate should be created
+      - hosts:
+          - demo.testkube.io
+        secretName: testkube-demo-cert-secret
+  cliIngress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        more_set_input_headers "X-CLI-Ingress: true";
+    # parameters to check oauth token (by default GitHub one)
+    oauth:
+      clientID: ""
+      clientSecret: ""
+      provider: "github"
+      scopes: ""
+    path: /api/(v\d/.*)
+    hosts:
+      - demo.testkube.io
+    tlsenabled: "false"
+    tls: # < placing a host in the TLS config will indicate a certificate should be created
+      - hosts:
+          - demo.testkube.io
+        secretName: testkube-demo-cert-secret
+  storage:
+    endpoint: ""
+    endpoint_port: "9000"
+    accessKeyId: "minio"
+    accessKey: "minio123"
+    location: ""
+    token: ""
+    bucket: "testkube-artifacts"
+    SSL: false
+    scrapperEnabled: true
+
+  ## Logs storage for Testkube API.
+  logs:
+    ## where the logs should be stored there are 2 possible valuse : minio|mongo
+    storage: "minio"
+    ## if storage is set to minio then the bucket must be specified, if minio with s3 is used make sure to use a unique name
+    bucket: "testkube-logs"
+
+  mongodb:
+    dsn: "mongodb://testkube-mongodb:27017"
+    # or you can pass mongo dsn from secret
+    # secretName: testkube-secrets
+    # secretKey: mongo-dsn
+    allowDiskUse: true
+
+  analyticsEnabled: true
+  slackToken: ""
+  slackSecret: ""
+  slackTemplate: ""
+  slackConfig: ""
+  executors: ""
+
+  ##Test Connection pod
+  testConnection:
+    enabled: true
+
+testkube-dashboard:
+  enabled: true
+  nameOverride: "dashboard"
+  fullnameOverride: "testkube-dashboard"
+  image:
+    repository: kubeshop/testkube-dashboard
+    pullPolicy: Always
+    #tag: "main" #it will take the tag from appVersion
+  service:
+    type: ClusterIP
+    port: 8080
+  ingress:
+    enabled: "true"
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+      nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
+      # specify the name of the global IP address resource to be associated with the HTTP(S) Load Balancer.
+      kubernetes.io/ingress.global-static-ip-name: testkube-demo
+      # add an annotation indicating the issuer to use.
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      # controls whether the ingress is modified ‘in-place’,
+      # or a new one is created specifically for the HTTP01 challenge.
+      acme.cert-manager.io/http01-edit-in-place: "true"
+    path: /
+    hosts:
+      - demo.testkube.io
+      - dashboard.testkube.io
+    tlsenabled: "true"
+    tls: # < placing a host in the TLS config will indicate a certificate should be created
+      - hosts:
+          - demo.testkube.io
+          - dashboard.testkube.io
+        secretName: testkube-demo-cert-secret
+  apiServerEndpoint: "demo.testkube.io/results" #get the address of the endpoint or set it using helm
+  oauth2:
+    enabled: false
+    name: oauth2-proxy
+    path: /oauth2
+    port: 4180
+    selector: k8s-app
+    image:
+      repository: quay.io/oauth2-proxy/oauth2-proxy
+      tag: latest
+      pullPolicy: Always
+    env:
+      clientId: ""
+      clientSecret: ""
+      githubOrg: ""
+      cookieSecret: ""
+      cookieSecure: "false"
+      redirectUrl: "http://demo.testkube.io/oauth2/callback"
+
+  ##Test Connection pod
+  testConnection:
+    enabled: true
+
+testkube-operator:
+  # should roles and roles bindings be created
+  rbac:
+    createRoles: true
+    createRoleBindings: true
+
+  # should the CRDs be installed
+  installCRD: true
+
+  ##Proxy Image parameters
+  ## image.registry Proxy image registry
+  ## image.repository Proxy image name
+  ## image.tag Proxy image tag
+  ## image.pullPolicy Proxy Image pull policy
+  proxy:
+    image:
+      registry: gcr.io
+      repository: kubebuilder/kube-rbac-proxy
+      tag: "v0.8.0"
+    ## Proxy Container Port
+    containerPort: 8443
+
+  ##Test Connection pod
+  testConnection:
+    enabled: true

--- a/k8s-examples/testkube/testkube-values.yaml
+++ b/k8s-examples/testkube/testkube-values.yaml
@@ -10,7 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets: []
+imagePullSecrets: [ ]
 nameOverride: "testkube"
 fullnameOverride: "testkube"
 
@@ -18,24 +18,24 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Annotations to add to the service account
-  annotations: {}
+  annotations: { }
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+podAnnotations: { }
 
 podSecurityContext:
-  {}
+  { }
 # fsGroup: 2000
 
 securityContext:
-  {}
+  { }
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
+# runAsNonRoot: true
 # runAsUser: 1000
 
 service:
@@ -46,21 +46,21 @@ ingress:
   enabled: "false"
   className: ""
   annotations:
-    {}
-    # kubernetes.io/ingress.class: nginx
+    { }
+  # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: []
+  tls: [ ]
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
 resources:
-  {}
+  { }
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -70,7 +70,7 @@ resources:
   #   memory: 128Mi
   # requests:
   #   cpu: 100m
-#   memory: 128Mi
+  #   memory: 128Mi
 
 autoscaling:
   enabled: false
@@ -79,11 +79,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }
 
 # For more configuration parameters of MongoDB chart please look here:
 # https://github.com/bitnami/charts/tree/master/bitnami/mongodb#parameters
@@ -120,9 +120,9 @@ testkube-api:
     port: 8088
   minio:
     enabled: true
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
+    nodeSelector: { }
+    tolerations: [ ]
+    affinity: { }
     image:
       registry: docker.io
       repository: minio/minio

--- a/k8s-examples/testkube/testkube-values.yaml
+++ b/k8s-examples/testkube/testkube-values.yaml
@@ -137,6 +137,9 @@ testkube-api:
       nginx.ingress.kubernetes.io/enable-cors: "true"
       nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
       nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
+      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+      nginx.ingress.kubernetes.io/access-control-allow-origin: "*"
       # specify the name of the global IP address resource to be associated with the HTTP(S) Load Balancer.
       #kubernetes.io/ingress.global-static-ip-name: testkube-demo
       # add an annotation indicating the issuer to use.
@@ -286,6 +289,8 @@ testkube-dashboard:
       nginx.ingress.kubernetes.io/enable-cors: "true"
       nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
       nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
+      nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+      nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
       # specify the name of the global IP address resource to be associated with the HTTP(S) Load Balancer.
       #kubernetes.io/ingress.global-static-ip-name: testkube-demo
       # add an annotation indicating the issuer to use.
@@ -308,8 +313,16 @@ testkube-dashboard:
     path: /oauth2
     port: 4180
     selector: k8s-app
+    args:
+      - --provider=github
+      - --scope=user:email
+      - --auth-logging=true
+      - --email-domain=*
+      - --upstream=file:///dev/null
+      - --show-debug-on-error=true
     image:
-      repository: quay.io/oauth2-proxy/oauth2-proxy
+      registry: quay.io
+      repository: oauth2-proxy/oauth2-proxy
       tag: latest
       pullPolicy: Always
     env:
@@ -318,7 +331,10 @@ testkube-dashboard:
       githubOrg: ""
       cookieSecret: ""
       cookieSecure: "false"
-      redirectUrl: "http://testkube.k8s.mabl.se/oauth2/callback"
+      redirectUrl: "https://testkube.k8s.mabl.se/oauth2/callback"
+    ingress:
+      annotations:
+        kubernetes.io/ingress.class: nginx
 
   ##Test Connection pod
   testConnection:

--- a/k8s-examples/testkube/testkube-values.yaml
+++ b/k8s-examples/testkube/testkube-values.yaml
@@ -138,9 +138,9 @@ testkube-api:
       nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
       nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
       # specify the name of the global IP address resource to be associated with the HTTP(S) Load Balancer.
-      kubernetes.io/ingress.global-static-ip-name: testkube-demo
+      #kubernetes.io/ingress.global-static-ip-name: testkube-demo
       # add an annotation indicating the issuer to use.
-      # cert-manager.io/cluster-issuer: letsencrypt-prod
+      # cert-manager.io/cluster-issuer: letsencrypt-production
       # controls whether the ingress is modified ‘in-place’,
       # or a new one is created specifically for the HTTP01 challenge.
       # acme.cert-manager.io/http01-edit-in-place: "true"
@@ -201,12 +201,12 @@ testkube-api:
 
     path: /results/(v\d/.*)
     hosts:
-      - demo.testkube.io
+      - testkube.k8s.mabl.se
     tlsenabled: "true"
     tls: # < placing a host in the TLS config will indicate a certificate should be created
       - hosts:
-          - demo.testkube.io
-        secretName: testkube-demo-cert-secret
+          - testkube.k8s.mabl.se
+        secretName: testkube-cert-secret
   cliIngress:
     enabled: true
     annotations:
@@ -224,12 +224,12 @@ testkube-api:
       scopes: ""
     path: /api/(v\d/.*)
     hosts:
-      - demo.testkube.io
+      - testkube.k8s.mabl.se
     tlsenabled: "false"
     tls: # < placing a host in the TLS config will indicate a certificate should be created
       - hosts:
-          - demo.testkube.io
-        secretName: testkube-demo-cert-secret
+          - testkube.k8s.mabl.se
+        secretName: testkube-cert-secret
   storage:
     endpoint: ""
     endpoint_port: "9000"
@@ -287,23 +287,21 @@ testkube-dashboard:
       nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
       nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
       # specify the name of the global IP address resource to be associated with the HTTP(S) Load Balancer.
-      kubernetes.io/ingress.global-static-ip-name: testkube-demo
+      #kubernetes.io/ingress.global-static-ip-name: testkube-demo
       # add an annotation indicating the issuer to use.
-      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/cluster-issuer: letsencrypt-production
       # controls whether the ingress is modified ‘in-place’,
       # or a new one is created specifically for the HTTP01 challenge.
       acme.cert-manager.io/http01-edit-in-place: "true"
     path: /
     hosts:
-      - demo.testkube.io
-      - dashboard.testkube.io
+      - testkube.k8s.mabl.se
     tlsenabled: "true"
     tls: # < placing a host in the TLS config will indicate a certificate should be created
       - hosts:
-          - demo.testkube.io
-          - dashboard.testkube.io
-        secretName: testkube-demo-cert-secret
-  apiServerEndpoint: "demo.testkube.io/results" #get the address of the endpoint or set it using helm
+          - testkube.k8s.mabl.se
+        secretName: testkube-cert-secret
+  apiServerEndpoint: "testkube.k8s.mabl.se/results" #get the address of the endpoint or set it using helm
   oauth2:
     enabled: false
     name: oauth2-proxy
@@ -320,7 +318,7 @@ testkube-dashboard:
       githubOrg: ""
       cookieSecret: ""
       cookieSecure: "false"
-      redirectUrl: "http://demo.testkube.io/oauth2/callback"
+      redirectUrl: "http://testkube.k8s.mabl.se/oauth2/callback"
 
   ##Test Connection pod
   testConnection:

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "eks_ami_type" {
 
 variable "node_group_instance_type" {
   description = "Type of AWS EKS node group instances to provision"
-  default     = "t3.medium"
+  default     = "t3.large"
 }
 
 variable "common_origin_tag" {


### PR DESCRIPTION
Here is a proof-of-concept deployment for a self-hosted Testkube site, a solution that would allows us to execute distributed load tests on a Kubernetes cluster using Artillery.io, cURL, JMeter, K6, and [many other test frameworks](https://kubeshop.github.io/testkube/category/test-types).

@kontrollanten, please verify you can login at https://testkube.k8s.mabl.se/ using your GitHub OAuth credentials and look around.

Current limitations (pending bug reports):
1. The [UI/dashboard authentication setup](https://kubeshop.github.io/testkube/guides/getting-to-production/authentication/oauth-ui) works to the extent that a user from the right GitHub org can login (after some tweaks for mitigating OAuth2-Proxy v7.3.x incompatibility), but once authenticated there is some CORS issue with GitHub that is blocking us from actually adding tests <img width="1073" alt="image" src="https://user-images.githubusercontent.com/123388211/221512094-cde58b77-73a7-49ea-9fe4-35758debeae5.png">
2. The [OAuth setup for CLI instruction](https://kubeshop.github.io/testkube/guides/getting-to-production/authentication/oauth-cli) does not work when running a remote cluster, because the `kubectl testkube config oauth https://testkube.k8s.mabl.se/api ...` command does not support creating a custom redirect URL, only redirects to localhost (see 49b3731 for example)

If we can get Testkube working, I think it could be a great tool for executing the `peertube-video-testing` load testing scripts at production scale and keeping track of test results. Any thoughts on this, @kontrollanten?